### PR TITLE
Handle `optional` plugin attribute, and handle not having a `requires` attribute

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,8 @@ async function load_plugin(code: string, app: JupyterFrontEnd) {
   // Finally, we allow returning a promise (or an async function above).
   plugin = await Promise.resolve(plugin);
 
-  plugin.requires = plugin.requires.map((value: any) => token_map.get(value));
+  plugin.requires = plugin.requires?.map((value: any) => token_map.get(value));
+  plugin.optional = plugin.optional?.map((value: any) => token_map.get(value));
 
   (app as any).registerPluginModule(plugin);
   if (plugin.autoStart) {


### PR DESCRIPTION
After this, this plugin works:

```javascript
{
  id: 'mydynamicplugin',
  autoStart: true,
  optional: ["@jupyterlab/apputils:ICommandPalette"],
  activate: function(app, palette) {
    // We can use app here to do something with the JupyterLab
    // app instance, such as adding a new command
    let commandID = "MySuperCoolDynamicCommand";
    let toggle = true;
    app.commands.addCommand(commandID, {
      label: 'My Super Cool Dynamic Command',
      isToggled: function() {
        return toggle;
      },
      execute: function() {
        toggle = !toggle;
      }
    });

    if(palette) {
    palette.addItem({
      command: commandID,
      // make it appear right at the top!
      category: 'AAA',
      args: {}
    });
    }
    console.log(app);
  }
}
```